### PR TITLE
use better lifetimes for compiler middlewares

### DIFF
--- a/lib/compiler/src/artifact_builders/artifact_builder.rs
+++ b/lib/compiler/src/artifact_builders/artifact_builder.rs
@@ -56,7 +56,7 @@ impl ArtifactBuild {
         // We try to apply the middleware first
         let mut module = translation.module;
         let middlewares = compiler.get_middlewares();
-        middlewares.apply_on_module_info(&mut module);
+        middlewares.apply_on_module_info(&mut module)?;
 
         let compile_info = CompileModuleInfo {
             module,

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -436,7 +436,7 @@ impl Artifact {
         use crate::translator::ModuleMiddlewareChain;
         let mut module = translation.module;
         let middlewares = compiler.get_middlewares();
-        middlewares.apply_on_module_info(&mut module);
+        middlewares.apply_on_module_info(&mut module)?;
 
         let memory_styles: PrimaryMap<MemoryIndex, MemoryStyle> = module
             .memories

--- a/lib/types/src/error.rs
+++ b/lib/types/src/error.rs
@@ -187,6 +187,12 @@ impl MiddlewareError {
     }
 }
 
+impl From<MiddlewareError> for CompileError {
+    fn from(error: MiddlewareError) -> Self {
+        WasmError::Middleware(error).into()
+    }
+}
+
 /// A WebAssembly translation error.
 ///
 /// When a WebAssembly function can't be translated, one of these error codes will be returned

--- a/tests/compilers/middlewares.rs
+++ b/tests/compilers/middlewares.rs
@@ -16,15 +16,15 @@ struct Add2Mul {
 }
 
 impl ModuleMiddleware for Add2MulGen {
-    fn generate_function_middleware(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware> {
+    fn generate_function_middleware<'a>(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware<'a> + 'a> {
         Box::new(Add2Mul {
             value_off: self.value_off,
         })
     }
 }
 
-impl FunctionMiddleware for Add2Mul {
-    fn feed<'a>(
+impl<'a> FunctionMiddleware<'a> for Add2Mul {
+    fn feed(
         &mut self,
         operator: Operator<'a>,
         state: &mut MiddlewareReaderState<'a>,
@@ -56,13 +56,13 @@ struct Fusion {
 }
 
 impl ModuleMiddleware for FusionGen {
-    fn generate_function_middleware(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware> {
+    fn generate_function_middleware<'a>(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware<'a> + 'a> {
         Box::new(Fusion { state: 0 })
     }
 }
 
-impl FunctionMiddleware for Fusion {
-    fn feed<'a>(
+impl<'a> FunctionMiddleware<'a> for Fusion {
+    fn feed(
         &mut self,
         operator: Operator<'a>,
         state: &mut MiddlewareReaderState<'a>,


### PR DESCRIPTION
Adopts the lifetime and fallibility changes of `#middleware-lifetimes-and-locals` for wasmer 3.1.0