### PR TITLE
Migrate from `wasm32-wasi` to `wasm32-wasip1`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,11 +204,6 @@ jobs:
         shell: bash
         run: |
           make build-wasmer
-     #- name: Build Wasmer binary on Wasm32-WASI without LLVM
-     #  if: matrix.build_wasm
-     #  shell: bash
-     #  run: |
-     #    make build-wasmer-wasm
       - name: Install Nightly Rust for Headless
         if: matrix.build != 'linux-musl-x64'
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           make distribution
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: dist
@@ -300,7 +300,7 @@ jobs:
           CARGO_TARGET: x86_64-pc-windows-gnu
           TARGET_DIR: target/x86_64-pc-windows-gnu/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'wasmer-windows-gnu64'
           path: dist
@@ -333,7 +333,7 @@ jobs:
           CARGO_TARGET: aarch64-apple-darwin
           TARGET_DIR: target/aarch64-apple-darwin/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'aarch64-apple-darwin-jsc'
           path: dist
@@ -362,7 +362,7 @@ jobs:
           CARGO_TARGET: x86_64-apple-darwin
           TARGET_DIR: target/x86_64-apple-darwin/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'x86_64-apple-darwin-jsc'
           path: dist
@@ -427,7 +427,7 @@ jobs:
           TARGET: aarch64-unknown-linux-gnu
           TARGET_DIR: target/aarch64-unknown-linux-gnu/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wasmer-linux-aarch64
           path: dist
@@ -492,7 +492,7 @@ jobs:
           TARGET: riscv64gc-unknown-linux-gnu
           TARGET_DIR: target/riscv64gc-unknown-linux-gnu/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wasmer-linux-riscv64
           path: dist

--- a/.github/workflows/check-public-api.yaml
+++ b/.github/workflows/check-public-api.yaml
@@ -38,7 +38,7 @@ jobs:
           cargo public-api --manifest-path=lib/api/Cargo.toml --diff-git-checkouts $LATEST_VERSION main > diff.txt
       
       - name: Archive change report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: api-diff-report
           path: |

--- a/.github/workflows/cloudcompiler.yaml
+++ b/.github/workflows/cloudcompiler.yaml
@@ -24,19 +24,19 @@ jobs:
         with:
           toolchain: ${{ env.MSRV }}
           target: ${{ matrix.target }}
-      - name: Install wasm32-wasi target
+      - name: Install wasm32-wasip1 target
         shell: bash
         run: |
-          rustup target add wasm32-wasi
+          rustup target add wasm32-wasip1
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v1
       - name: Build cloudcompiler.wasm
         shell: bash
         run: |
           make build-wasmer-wasm &&
-          mkdir target/wasm32-wasi/release/cloudcompiler
-          cp target/wasm32-wasi/release/wasmer-compiler.wasm target/wasm32-wasi/release/cloudcompiler/cloudcompiler.wasm &&
-          cat << EOF > target/wasm32-wasi/release/cloudcompiler/wasmer.toml
+          mkdir target/wasm32-wasip1/release/cloudcompiler
+          cp target/wasm32-wasip1/release/wasmer-compiler.wasm target/wasm32-wasip1/release/cloudcompiler/cloudcompiler.wasm &&
+          cat << EOF > target/wasm32-wasip1/release/cloudcompiler/wasmer.toml
           [package]
           name = "${{ secrets.WAPM_DEV_USERNAME }}/cloudcompiler"
           version = "0.1.0"
@@ -61,18 +61,18 @@ jobs:
           echo $(git tag | tail -n1) > ./version.txt
           v=$(git describe --tags --abbrev=0) && \
           echo "version = ${v}" &&
-          sed -i "s/version = \".*\"/version = \"${v}\"/g" target/wasm32-wasi/release/cloudcompiler/wasmer.toml \
+          sed -i "s/version = \".*\"/version = \"${v}\"/g" target/wasm32-wasip1/release/cloudcompiler/wasmer.toml \
       - name: Build cloudcompiler.wasm
         shell: bash
         run: |
           git tag &&
-          cat target/wasm32-wasi/release/cloudcompiler/wasmer.toml &&
+          cat target/wasm32-wasip1/release/cloudcompiler/wasmer.toml &&
           echo "ls" &&
-          ls target/wasm32-wasi/release/cloudcompiler
+          ls target/wasm32-wasip1/release/cloudcompiler
       - name: Publish to WAPM
         uses: wasmerio/wapm-publish@v1
         with:
           registry: https://registry.wapm.dev
-          directory: target/wasm32-wasi/release/cloudcompiler
+          directory: target/wasm32-wasip1/release/cloudcompiler
           username: ${{ secrets.WAPM_DEV_USERNAME }}
           password: ${{ secrets.WAPM_DEV_PASSWORD }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -272,7 +272,7 @@ jobs:
           TARGET_DIR: target/aarch64-unknown-linux-gnu/release
       - name: Upload Artifacts
         if: ${{ matrix.build-what.key == 'capi' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: capi-linux-aarch64
           path: dist
@@ -330,7 +330,7 @@ jobs:
           TARGET_DIR: target/riscv64gc-unknown-linux-gnu/release
       - name: Upload Artifacts
         if: ${{ matrix.build-what.key == 'capi' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: capi-linux-riscv64
           path: dist
@@ -538,14 +538,14 @@ jobs:
           TARGET_DIR: target/${{ matrix.metadata.target }}/release
           CARGO_TARGET: ${{ matrix.metadata.target }}
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wasmer-cli-${{ matrix.metadata.build }}
           path: build-wasmer.tar.gz
           if-no-files-found: ignore
           retention-days: 2
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: capi-${{ matrix.metadata.build }}
           path: build-capi.tar.gz

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-          targets: "wasm32-wasi"
+          targets: "wasm32-wasip1"
       - name: Install wasm-pack
         run: |
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -183,8 +183,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: rustup target add wasm32-wasi
-        run: rustup target add wasm32-wasi
+      - name: rustup target add wasm32-wasip1
+        run: rustup target add wasm32-wasip1
       - name: make build-wasmer-wasm
         run: make build-wasmer-wasm
 

--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ check-wasmer:
 	$(CARGO_BINARY) check $(CARGO_TARGET_FLAG) --manifest-path lib/cli/Cargo.toml $(compiler_features) --bin wasmer --locked
 
 check-wasmer-wasm:
-	$(CARGO_BINARY) check --manifest-path lib/cli-compiler/Cargo.toml --target wasm32-wasi --features singlepass,cranelift --bin wasmer-compiler --locked
+	$(CARGO_BINARY) check --manifest-path lib/cli-compiler/Cargo.toml --target wasm32-wasip1 --features singlepass,cranelift --bin wasmer-compiler --locked
 
 check-capi:
 	RUSTFLAGS="${RUSTFLAGS}" $(CARGO_BINARY) check $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml  \
@@ -396,7 +396,7 @@ bench:
 	$(CARGO_BINARY) bench $(CARGO_TARGET_FLAG) $(compiler_features)
 
 build-wasmer-wasm:
-	$(CARGO_BINARY) build --release --manifest-path lib/cli-compiler/Cargo.toml --target wasm32-wasi --features singlepass,cranelift --bin wasmer-compiler --locked
+	$(CARGO_BINARY) build --release --manifest-path lib/cli-compiler/Cargo.toml --target wasm32-wasip1 --features singlepass,cranelift --bin wasmer-compiler --locked
 
 # For best results ensure the release profile looks like the following
 # in Cargo.toml:
@@ -638,12 +638,12 @@ test-wasix: build-wasmer
 
 test-integration-cli: build-wasmer build-capi package-capi-headless package distribution
 	cp ./dist/wasmer.tar.gz ./link.tar.gz
-	rustup target add wasm32-wasi
+	rustup target add wasm32-wasip1
 	WASMER_DIR=`pwd`/package $(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --features webc_runner --no-fail-fast -p wasmer-integration-tests-cli --locked
 
 # Before running this in the CI, we need to set up link.tar.gz and /cache/wasmer-[target].tar.gz
 test-integration-cli-ci: require-nextest
-	rustup target add wasm32-wasi
+	rustup target add wasm32-wasip1
 	$(CARGO_BINARY) nextest run $(CARGO_TARGET_FLAG) --features webc_runner -p wasmer-integration-tests-cli --locked
 
 test-integration-ios:

--- a/docs/en/examples-coredump.md
+++ b/docs/en/examples-coredump.md
@@ -5,7 +5,7 @@ The following steps describe how to debug using Wasm coredump in Wasmer:
 1. Compile your WebAssembly with debug info enabled; for example: 
 
     ```sh
-    $ rustc foo.rs --target=wasm32-wasi -C debuginfo=2
+    $ rustc foo.rs --target=wasm32-wasip1 -C debuginfo=2
     ```
 
 <details>

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -417,7 +417,7 @@ compile_error!("The `jsc` feature must be enabled only for non-`wasm32` target."
 
 #[cfg(all(feature = "js", not(target_arch = "wasm32")))]
 compile_error!(
-    "The `js` feature must be enabled only for the `wasm32` target (either `wasm32-unknown-unknown` or `wasm32-wasi`)."
+    "The `js` feature must be enabled only for the `wasm32` target (either `wasm32-unknown-unknown` or `wasm32-wasip1`)."
 );
 
 mod access;

--- a/lib/cli/src/commands/init.rs
+++ b/lib/cli/src/commands/init.rs
@@ -554,6 +554,6 @@ fn parse_cargo_toml(manifest_path: &PathBuf) -> Result<MiniCargoTomlPackage, any
         build_dir: metadata
             .target_directory
             .into_std_path_buf()
-            .join("wasm32-wasi"),
+            .join("wasm32-wasip1"),
     })
 }

--- a/lib/config/src/package/mod.rs
+++ b/lib/config/src/package/mod.rs
@@ -1022,12 +1022,12 @@ license = "MIT"
 
 [[module]]
 name = "mod"
-source = "target/wasm32-wasi/release/mod.wasm"
+source = "target/wasm32-wasip1/release/mod.wasm"
 interfaces = {"wasi" = "0.0.0-unstable"}
 
 [[module]]
 name = "mod-with-exports"
-source = "target/wasm32-wasi/release/mod-with-exports.wasm"
+source = "target/wasm32-wasip1/release/mod-with-exports.wasm"
 bindings = { wit-exports = "exports.wit", wit-bindgen = "0.0.0" }
 
 [[command]]
@@ -1045,7 +1045,7 @@ module = "mod"
             modules[1],
             Module {
                 name: "mod-with-exports".to_string(),
-                source: PathBuf::from("target/wasm32-wasi/release/mod-with-exports.wasm"),
+                source: PathBuf::from("target/wasm32-wasip1/release/mod-with-exports.wasm"),
                 abi: Abi::None,
                 kind: None,
                 interfaces: None,

--- a/lib/wasix/README.md
+++ b/lib/wasix/README.md
@@ -8,7 +8,7 @@ is being standardized in the WebAssembly subgroup.
 Very succinctly, from the user perspective, WASI is a set of
 WebAssembly module _imports_ under a specific _namespace_ (which
 varies based on the WASI version). A program compiled for the
-`wasm32-wasi` target will be able to support standard I/O, file I/O,
+`wasm32-wasip1` target will be able to support standard I/O, file I/O,
 filesystem manipulation, memory management, time, string, environment
 variables, program startup etc.
 
@@ -47,7 +47,7 @@ fn main() {
 Then, let's compile it to a WebAssembly module with WASI support:
 
 ```sh
-$ rustc --target wasm32-wasi hello.rs
+$ rustc --target wasm32-wasip1 hello.rs
 ```
 
 Finally, let's execute it with the `wasmer` CLI:

--- a/lib/wasix/src/lib.rs
+++ b/lib/wasix/src/lib.rs
@@ -27,7 +27,7 @@ compile_error!("The `sys` feature must be enabled only for non-`wasm32` target."
 
 #[cfg(all(feature = "js", not(target_arch = "wasm32")))]
 compile_error!(
-    "The `js` feature must be enabled only for the `wasm32` target (either `wasm32-unknown-unknown` or `wasm32-wasi`)."
+    "The `js` feature must be enabled only for the `wasm32` target (either `wasm32-unknown-unknown` or `wasm32-wasip1`)."
 );
 
 #[cfg(all(test, target_arch = "wasm32"))]

--- a/tests/integration/cli/tests/fixtures/init4.toml
+++ b/tests/integration/cli/tests/fixtures/init4.toml
@@ -7,7 +7,7 @@ description = 'Description for package wasmer'
 
 [[module]]
 name = 'wasmer'
-source = 'target/wasm32-wasi/release/wasmer.wasm'
+source = 'target/wasm32-wasip1/release/wasmer.wasm'
 abi = 'wasi'
 
 [module.interfaces]

--- a/tests/integration/cli/tests/publish.rs
+++ b/tests/integration/cli/tests/publish.rs
@@ -116,7 +116,7 @@ fn wasmer_init_publish() {
         .arg("build")
         .arg("--release")
         .arg("--target")
-        .arg("wasm32-wasi")
+        .arg("wasm32-wasip1")
         .arg("--manifest-path")
         .arg(path.join("randomversion").join("Cargo.toml"))
         .assert()

--- a/tests/wasi-fyi/build.sh
+++ b/tests/wasi-fyi/build.sh
@@ -5,5 +5,5 @@ for input in *.rs; do
   output="$(basename $input .rs).wasm"
 
   echo "Compiling $input"
-  rustc +nightly --target=wasm32-wasi -o "$output" "$input"
+  rustc +nightly --target=wasm32-wasip1 -o "$output" "$input"
 done

--- a/tests/wasi-wast/src/set_up_toolchain.rs
+++ b/tests/wasi-wast/src/set_up_toolchain.rs
@@ -17,7 +17,7 @@ fn install_toolchain(toolchain_name: &str) {
     let rustup_out = Command::new("rustup")
         .arg("target")
         .arg("add")
-        .arg("wasm32-wasi")
+        .arg("wasm32-wasip1")
         .arg("--toolchain")
         .arg(toolchain_name)
         .output()

--- a/tests/wasi-wast/src/wasitests.rs
+++ b/tests/wasi-wast/src/wasitests.rs
@@ -159,7 +159,7 @@ fn compile_wasm_for_version(
 
     command
         .arg(format!("+{}", version.get_compiler_toolchain()))
-        .arg("--target=wasm32-wasi")
+        .arg("--target=wasm32-wasip1")
         .arg("-C")
         .arg("opt-level=z")
         .arg(&temp_wasi_rs_file_name)


### PR DESCRIPTION
Needed for [NIT-3220](https://linear.app/offchain-labs/issue/NIT-3220/use-wasm32-wasip1-in-arbitrator-rust)

Migrate from `wasm32-wasi` to `wasm32-wasip1` according to https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets/