### PR TITLE
Fix missing exports from baremetal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -5391,7 +5391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7028,7 +7028,7 @@ dependencies = [
  "clap_lex",
  "criterion",
  "hex",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tempfile",
  "thiserror 2.0.18",
  "wasmer",
@@ -7327,7 +7327,7 @@ dependencies = [
  "once_cell",
  "predicates 3.1.4",
  "pretty_assertions",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "reqwest",
  "serde",
@@ -7440,7 +7440,7 @@ dependencies = [
  "bytesize",
  "futures-util",
  "ignore",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest",
  "semver 1.0.27",
  "serde",
@@ -7585,7 +7585,7 @@ dependencies = [
  "pin-project",
  "pin-utils",
  "pretty_assertions",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "reqwest",
  "rkyv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4769,9 +4769,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/lib/vm/src/trap/traphandlers_baremetal.rs
+++ b/lib/vm/src/trap/traphandlers_baremetal.rs
@@ -3,7 +3,6 @@ use crate::{Trap, VMContext, VMFunctionBody};
 use std::any::Any;
 use std::error::Error;
 use std::mem;
-use bytesize::ByteSize;
 
 /// Dummy trap handler type for baremetal mode
 pub type TrapHandlerFn<'a> = ();

--- a/lib/vm/src/trap/traphandlers_baremetal.rs
+++ b/lib/vm/src/trap/traphandlers_baremetal.rs
@@ -3,6 +3,7 @@ use crate::{Trap, VMContext, VMFunctionBody};
 use std::any::Any;
 use std::error::Error;
 use std::mem;
+use bytesize::ByteSize;
 
 /// Dummy trap handler type for baremetal mode
 pub type TrapHandlerFn<'a> = ();
@@ -13,10 +14,23 @@ pub struct VMConfig {
     pub wasm_stack_size: Option<usize>,
 }
 
-/// Baremetal does not support setting stack size, the function is kept
-/// here to preserve APIs
+
+/// Baremetal does not support setting stack size, the const is kept here to preserve APIs
+pub const MAX_STACK_SIZE: usize = 0;
+
+/// Baremetal does not support setting stack size, the function is kept here to preserve APIs
 pub fn set_stack_size(_size: usize) {
     panic!("Setting stack size is not supported in baremetal feature!");
+}
+
+/// Baremetal does not support getting stack size, the function is kept here to preserve APIs
+pub fn get_stack_size() -> usize {
+    panic!("Getting stack size is not supported in baremetal feature!");
+}
+
+/// Baremetal does not support draining stack pool, the function is kept here to preserve APIs
+pub fn drain_stack_pool() {
+    panic!("Draining stack pool is not supported in baremetal feature!");
 }
 
 /// In baremetal mode, init_traps does nothing

--- a/lib/vm/src/trap/traphandlers_baremetal.rs
+++ b/lib/vm/src/trap/traphandlers_baremetal.rs
@@ -13,7 +13,6 @@ pub struct VMConfig {
     pub wasm_stack_size: Option<usize>,
 }
 
-
 /// Baremetal does not support setting stack size, the const is kept here to preserve APIs
 pub const MAX_STACK_SIZE: usize = 0;
 


### PR DESCRIPTION
Adapts changes from https://github.com/OffchainLabs/wasmer/pull/37 for the `traphandlers_baremetal.rs` module